### PR TITLE
perf(transformer): decode large responses on worker isolate

### DIFF
--- a/lib/src/api_options/api_options.dart
+++ b/lib/src/api_options/api_options.dart
@@ -12,6 +12,7 @@ class ApiOptions {
     this.cancelToken,
     this.ignoreAutoRefresh = true,
     this.responseType,
+    this.isolateDecodeThreshold,
   });
   ResponseType? responseType;
 
@@ -32,4 +33,12 @@ class ApiOptions {
   CancelToken? cancelToken;
 
   bool? ignoreAutoRefresh;
+
+  /// Content-length threshold (in bytes) above which response JSON decoding
+  /// moves to a Dio worker isolate. Only honored when set on the [ApiOptions]
+  /// passed to `ApiServiceImpl`'s constructor (transformers are client-scoped,
+  /// so per-request values are ignored). `null` uses the client default of
+  /// 50 KiB. `-1` keeps all decoding on the main isolate; `0` sends every
+  /// decode to an isolate.
+  int? isolateDecodeThreshold;
 }

--- a/lib/src/api_service_impl.dart
+++ b/lib/src/api_service_impl.dart
@@ -17,7 +17,12 @@ class ApiServiceImpl implements ApiService {
     this.apiOptions,
     this.sslConfig,
   }) {
+    final decodeThreshold = apiOptions?.isolateDecodeThreshold ?? 50 * 1024;
+    Transformer buildTransformer() =>
+        FusedTransformer(contentLengthIsolateThreshold: decodeThreshold);
+
     _dio = Dio()
+      ..transformer = buildTransformer()
       ..options.contentType = Headers.jsonContentType
       ..options.connectTimeout =
           apiOptions?.connectTimeout ?? Duration(minutes: 1)
@@ -29,6 +34,7 @@ class ApiServiceImpl implements ApiService {
     }
 
     _dioFile = Dio()
+      ..transformer = buildTransformer()
       ..options.connectTimeout = Duration(minutes: 1)
       ..options.receiveTimeout = Duration(minutes: 1, seconds: 30);
 
@@ -36,7 +42,7 @@ class ApiServiceImpl implements ApiService {
       _dioFile!.interceptors.addAll(interceptors!);
     }
 
-    _refreshTokenDio = Dio();
+    _refreshTokenDio = Dio()..transformer = buildTransformer();
     if (interceptors != null && interceptors!.isNotEmpty && isDebug) {
       _refreshTokenDio!.interceptors.add(RefreshTokenLoggingInterceptorImpl());
     }


### PR DESCRIPTION
Install FusedTransformer with a contentLengthIsolateThreshold (default 50 KiB, configurable via ApiOptions.isolateDecodeThreshold) on all Dio instances so large JSON responses no longer block the main isolate.